### PR TITLE
Fix Bless Error

### DIFF
--- a/ClashXR/Info.plist
+++ b/ClashXR/Info.plist
@@ -85,7 +85,7 @@
 	<key>SMPrivilegedExecutables</key>
 	<dict>
 		<key>com.west2online.ClashXR.ProxyConfigHelper</key>
-		<string>identifier "com.west2online.ClashXR.ProxyConfigHelper" and anchor apple generic and certificate leaf[subject.CN] = "Apple Distribution: Mark Jerry (8U6T3TBX56)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
+		<string>anchor apple generic and identifier "com.west2online.ClashXR.ProxyConfigHelper" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8U6T3TBX56"</string>
 	</dict>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>


### PR DESCRIPTION
ClashXR不能成功安装ProxyConfigHelper，系统代理不能自动设置。~/Logs/ClashXR/中出现：
```
2019/11/22 18:22:36:192  [info] installHelperDaemon
2019/11/22 18:22:40:842  [error] Bless Error: Error Domain=CFErrorDomainLaunchd Code=4 "(null)"
```

Console中出现
```
default	13:13:33.902182+0800	smd	App "com.west2online.ClashXR" did not pass helper check "com.west2online.ClashXR.ProxyConfigHelper".
```

使用https://developer.apple.com/library/archive/samplecode/SMJobBless/Introduction/Intro.html 里提供的SMJobBlessUtil.py check，输出结果：
```
SMJobBlessUtil.py: tool designated requirement (anchor apple generic and identifier "com.west2online.ClashXR.ProxyConfigHelper" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8U6T3TBX56")) doesn't match entry in 'SMPrivilegedExecutables' (identifier "com.west2online.ClashXR.ProxyConfigHelper" and anchor apple generic and certificate leaf[subject.CN] = "Apple Distribution: Mark Jerry (8U6T3TBX56)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */)
```

不是很确定这么改是否正确